### PR TITLE
Add coverage demo example showing partial code coverage

### DIFF
--- a/usage/coverage_demo/.pzspec
+++ b/usage/coverage_demo/.pzspec
@@ -1,0 +1,4 @@
+[pzspec]
+library_name = calculator
+build_dir = zig-out/lib
+auto_build = true

--- a/usage/coverage_demo/build.zig
+++ b/usage/coverage_demo/build.zig
@@ -1,0 +1,25 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    // Create a module from the source file with target
+    const lib_module = b.addModule("calculator", .{
+        .root_source_file = b.path("src/calculator.zig"),
+        .target = target,
+    });
+
+    // Create a shared library that can be loaded by Python via FFI
+    const lib = b.addLibrary(.{
+        .name = "calculator",
+        .root_module = lib_module,
+    });
+    lib.root_module.optimize = optimize;
+
+    // Set to dynamic linkage for shared library
+    lib.linkage = .dynamic;
+
+    // Install the library
+    b.installArtifact(lib);
+}

--- a/usage/coverage_demo/pzspec/test_calculator.py
+++ b/usage/coverage_demo/pzspec/test_calculator.py
@@ -1,0 +1,85 @@
+"""
+Test suite for Calculator library - demonstrates partial code coverage.
+
+This test file intentionally only tests some functions to show
+how coverage reports highlight untested code.
+"""
+
+import sys
+from pathlib import Path
+
+# Add the parent PZSpec to the path
+project_root = Path(__file__).parent.parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+from pzspec.zig_ffi import ZigLibrary
+from pzspec.dsl import describe, it, expect
+import ctypes
+
+
+# Load the Zig library
+zig = ZigLibrary()
+
+
+# Test only basic arithmetic - leaving advanced operations untested
+with describe("Calculator - Basic Arithmetic"):
+
+    @it("should add two numbers")
+    def test_add():
+        func = zig.get_function("add", [ctypes.c_int32, ctypes.c_int32], ctypes.c_int32)
+        expect(func(2, 3)).to_equal(5)
+        expect(func(-1, 1)).to_equal(0)
+        expect(func(0, 0)).to_equal(0)
+
+    @it("should subtract two numbers")
+    def test_subtract():
+        func = zig.get_function("subtract", [ctypes.c_int32, ctypes.c_int32], ctypes.c_int32)
+        expect(func(5, 3)).to_equal(2)
+        expect(func(3, 5)).to_equal(-2)
+
+    @it("should multiply two numbers")
+    def test_multiply():
+        func = zig.get_function("multiply", [ctypes.c_int32, ctypes.c_int32], ctypes.c_int32)
+        expect(func(3, 4)).to_equal(12)
+        expect(func(-2, 3)).to_equal(-6)
+        expect(func(0, 100)).to_equal(0)
+
+
+with describe("Calculator - Division"):
+
+    @it("should divide two numbers")
+    def test_divide():
+        func = zig.get_function("divide", [ctypes.c_int32, ctypes.c_int32], ctypes.c_int32)
+        expect(func(10, 2)).to_equal(5)
+        expect(func(7, 3)).to_equal(2)  # Integer division
+
+    # Note: We're NOT testing division by zero!
+    # This branch will show as uncovered
+
+
+with describe("Calculator - Even/Odd Check"):
+
+    @it("should check if number is even")
+    def test_is_even():
+        func = zig.get_function("is_even", [ctypes.c_int32], ctypes.c_bool)
+        expect(func(4)).to_equal(True)
+        expect(func(3)).to_equal(False)
+        expect(func(0)).to_equal(True)
+
+    # Note: We're NOT testing is_odd!
+    # This function will show as completely uncovered
+
+
+# Note: The following functions are NOT tested at all:
+# - power()
+# - factorial()
+# - fibonacci()
+# - max()
+# - min()
+# - abs()
+# - sign()
+# - gcd()
+# - is_odd()
+#
+# Run with: pzspec --coverage
+# to see these functions marked as uncovered

--- a/usage/coverage_demo/src/calculator.zig
+++ b/usage/coverage_demo/src/calculator.zig
@@ -1,0 +1,127 @@
+// Calculator Library - Demonstrates partial coverage
+// Some functions will be tested, others will remain untested
+
+const std = @import("std");
+
+// Basic arithmetic operations (will be tested)
+export fn add(a: i32, b: i32) i32 {
+    return a + b;
+}
+
+export fn subtract(a: i32, b: i32) i32 {
+    return a - b;
+}
+
+export fn multiply(a: i32, b: i32) i32 {
+    return a * b;
+}
+
+// Division with error handling (partially tested)
+export fn divide(a: i32, b: i32) i32 {
+    if (b == 0) {
+        return 0; // Return 0 for division by zero
+    }
+    return @divTrunc(a, b);
+}
+
+// Advanced operations (NOT tested - will show as uncovered)
+export fn power(base: i32, exp: i32) i32 {
+    if (exp < 0) {
+        return 0; // Negative exponents return 0 for integers
+    }
+    if (exp == 0) {
+        return 1;
+    }
+    var result: i32 = 1;
+    var i: i32 = 0;
+    while (i < exp) : (i += 1) {
+        result *= base;
+    }
+    return result;
+}
+
+export fn factorial(n: i32) i32 {
+    if (n < 0) {
+        return 0; // Invalid input
+    }
+    if (n <= 1) {
+        return 1;
+    }
+    var result: i32 = 1;
+    var i: i32 = 2;
+    while (i <= n) : (i += 1) {
+        result *= i;
+    }
+    return result;
+}
+
+export fn fibonacci(n: i32) i32 {
+    if (n < 0) {
+        return 0;
+    }
+    if (n <= 1) {
+        return n;
+    }
+    var a: i32 = 0;
+    var b: i32 = 1;
+    var i: i32 = 2;
+    while (i <= n) : (i += 1) {
+        const temp = a + b;
+        a = b;
+        b = temp;
+    }
+    return b;
+}
+
+// Comparison functions (NOT tested)
+export fn max(a: i32, b: i32) i32 {
+    if (a > b) {
+        return a;
+    }
+    return b;
+}
+
+export fn min(a: i32, b: i32) i32 {
+    if (a < b) {
+        return a;
+    }
+    return b;
+}
+
+export fn abs(n: i32) i32 {
+    if (n < 0) {
+        return -n;
+    }
+    return n;
+}
+
+// Sign function (NOT tested)
+export fn sign(n: i32) i32 {
+    if (n > 0) {
+        return 1;
+    } else if (n < 0) {
+        return -1;
+    }
+    return 0;
+}
+
+// Check if number is even/odd (partially tested)
+export fn is_even(n: i32) bool {
+    return @mod(n, 2) == 0;
+}
+
+export fn is_odd(n: i32) bool {
+    return @mod(n, 2) != 0;
+}
+
+// GCD function (NOT tested)
+export fn gcd(a: i32, b: i32) i32 {
+    var x = abs(a);
+    var y = abs(b);
+    while (y != 0) {
+        const temp = @mod(x, y);
+        x = y;
+        y = temp;
+    }
+    return x;
+}


### PR DESCRIPTION
## Summary

- Adds `usage/coverage_demo/` example that demonstrates the code coverage feature
- Calculator library with 14 functions, only 5 tested intentionally
- Shows how coverage reports highlight untested code

## Coverage Results

```
============================================================
Coverage Report
============================================================
  ✗ calculator.zig                  23.1%  (6/26)
------------------------------------------------------------
  Total Coverage: 23.1%
  Functions: 5/14 (35.7%)
  Branches:  1/12 (8.3%)
============================================================
```

**Tested:** `add`, `subtract`, `multiply`, `divide`, `is_even`

**Untested:** `power`, `factorial`, `fibonacci`, `max`, `min`, `abs`, `sign`, `gcd`, `is_odd`

## Usage

```bash
cd usage/coverage_demo
pzspec --coverage              # Terminal summary
pzspec --coverage --html cov/  # HTML report
```

## Test plan

- [x] Verify `pzspec --coverage` shows < 100% coverage
- [x] Verify HTML report generation works
- [x] Confirm all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)