### PR TITLE
Add mocking/stubbing support for Zig functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,7 @@ jobs:
       - name: Run factory_demo tests
         working-directory: usage/factory_demo
         run: pzspec
+
+      - name: Run payment_service tests (mocking)
+        working-directory: usage/payment_service
+        run: pzspec

--- a/pzspec/__init__.py
+++ b/pzspec/__init__.py
@@ -35,6 +35,14 @@ from .dsl import (
     before,
     after,
 )
+from .mock import (
+    mock_zig_function,
+    assert_called,
+    assert_called_once,
+    assert_called_with,
+    get_call_count,
+    get_calls,
+)
 
 # CLI is available but not exported by default
 # Access via: from pzspec.cli import main
@@ -69,6 +77,12 @@ __all__ = [
     "after_each",
     "before",
     "after",
+    "mock_zig_function",
+    "assert_called",
+    "assert_called_once",
+    "assert_called_with",
+    "get_call_count",
+    "get_calls",
 ]
 
 __version__ = "0.1.0"

--- a/pzspec/mock.py
+++ b/pzspec/mock.py
@@ -1,0 +1,246 @@
+"""
+Mocking and stubbing support for Zig functions via FFI.
+
+Provides context managers for temporarily replacing Zig function behavior
+during tests. This is implemented at the FFI layer using ctypes.
+
+Note: This approach has limitations:
+- Only works with functions accessed through ZigLibrary
+- Cannot mock internal Zig-to-Zig calls
+- Functions must be accessed via get_function() after mock is set up
+"""
+
+import ctypes
+from typing import Any, Callable, List, Optional, Union
+from dataclasses import dataclass, field
+from contextlib import contextmanager
+
+
+@dataclass
+class MockCall:
+    """Record of a call to a mocked function."""
+    args: tuple
+    kwargs: dict = field(default_factory=dict)
+
+
+@dataclass
+class MockConfig:
+    """Configuration for a mocked function."""
+    returns: Any = None
+    returns_sequence: Optional[List[Any]] = None
+    side_effect: Optional[Callable] = None
+    call_count: int = 0
+    calls: List[MockCall] = field(default_factory=list)
+    _sequence_index: int = 0
+
+
+class MockRegistry:
+    """
+    Registry of active mocks for Zig functions.
+
+    This is used by ZigLibrary to intercept function calls and return
+    mocked values instead of calling the actual Zig function.
+    """
+
+    def __init__(self):
+        self._mocks: dict = {}
+        self._original_functions: dict = {}
+
+    def register_mock(self, name: str, config: MockConfig):
+        """Register a mock for a function."""
+        self._mocks[name] = config
+
+    def unregister_mock(self, name: str):
+        """Remove a mock for a function."""
+        if name in self._mocks:
+            del self._mocks[name]
+
+    def is_mocked(self, name: str) -> bool:
+        """Check if a function is mocked."""
+        return name in self._mocks
+
+    def get_mock_config(self, name: str) -> Optional[MockConfig]:
+        """Get the mock configuration for a function."""
+        return self._mocks.get(name)
+
+    def call_mock(self, name: str, *args, **kwargs) -> Any:
+        """
+        Call a mocked function and return the configured result.
+
+        Records the call and returns the appropriate value based on
+        the mock configuration.
+        """
+        config = self._mocks.get(name)
+        if config is None:
+            raise ValueError(f"No mock registered for '{name}'")
+
+        # Record the call
+        config.calls.append(MockCall(args=args, kwargs=kwargs))
+        config.call_count += 1
+
+        # Handle side_effect (callable)
+        if config.side_effect is not None:
+            return config.side_effect(*args, **kwargs)
+
+        # Handle returns_sequence
+        if config.returns_sequence is not None:
+            if config._sequence_index < len(config.returns_sequence):
+                result = config.returns_sequence[config._sequence_index]
+                config._sequence_index += 1
+                return result
+            # If sequence exhausted, return the last value
+            return config.returns_sequence[-1] if config.returns_sequence else None
+
+        # Handle simple returns
+        return config.returns
+
+    def clear_all(self):
+        """Clear all mocks."""
+        self._mocks.clear()
+
+
+# Global mock registry
+_mock_registry = MockRegistry()
+
+
+def get_mock_registry() -> MockRegistry:
+    """Get the global mock registry."""
+    return _mock_registry
+
+
+@contextmanager
+def mock_zig_function(
+    name: str,
+    returns: Any = None,
+    returns_sequence: Optional[List[Any]] = None,
+    side_effect: Optional[Callable] = None,
+):
+    """
+    Context manager to mock a Zig function during a test.
+
+    The mock intercepts calls to the function made through ZigLibrary.get_function()
+    and returns the configured values instead of calling the actual Zig code.
+
+    Args:
+        name: The name of the Zig function to mock
+        returns: A fixed value to return for all calls
+        returns_sequence: A sequence of values to return in order
+        side_effect: A callable to execute instead of the function
+
+    Usage:
+        with mock_zig_function("external_api", returns=42):
+            result = zig.get_function("external_api", [], ctypes.c_int32)()
+            assert result == 42
+
+        with mock_zig_function("retry_func", returns_sequence=[False, False, True]):
+            # First call returns False, second False, third True
+            ...
+
+        def my_side_effect(x):
+            return x * 2
+
+        with mock_zig_function("compute", side_effect=my_side_effect):
+            result = zig.get_function("compute", [ctypes.c_int32], ctypes.c_int32)(21)
+            assert result == 42
+
+    Note:
+        - The mock only works for functions retrieved AFTER entering the context
+        - Functions cached before the mock won't be affected
+        - Internal Zig-to-Zig calls are not intercepted
+    """
+    config = MockConfig(
+        returns=returns,
+        returns_sequence=returns_sequence,
+        side_effect=side_effect,
+    )
+
+    registry = get_mock_registry()
+    registry.register_mock(name, config)
+
+    try:
+        yield config
+    finally:
+        registry.unregister_mock(name)
+
+
+class MockFunction:
+    """
+    A wrapper that acts like a ctypes function but returns mocked values.
+
+    This is returned by ZigLibrary.get_function() when the function is mocked.
+    """
+
+    def __init__(self, name: str, argtypes: List, restype):
+        self.name = name
+        self.argtypes = argtypes
+        self.restype = restype
+        self._registry = get_mock_registry()
+
+    def __call__(self, *args, **kwargs):
+        """Call the mock and return the configured result."""
+        result = self._registry.call_mock(self.name, *args, **kwargs)
+
+        # Convert result to the expected return type if needed
+        if self.restype is not None and result is not None:
+            if self.restype == ctypes.c_int32:
+                return int(result)
+            elif self.restype == ctypes.c_float:
+                return float(result)
+            elif self.restype == ctypes.c_double:
+                return float(result)
+            elif self.restype == ctypes.c_bool:
+                return bool(result)
+
+        return result
+
+
+def assert_called(name: str, msg: Optional[str] = None):
+    """Assert that a mocked function was called at least once."""
+    config = get_mock_registry().get_mock_config(name)
+    if config is None:
+        raise AssertionError(f"No mock registered for '{name}'")
+    if config.call_count == 0:
+        error_msg = msg or f"Expected '{name}' to be called, but it was not"
+        raise AssertionError(error_msg)
+
+
+def assert_called_once(name: str, msg: Optional[str] = None):
+    """Assert that a mocked function was called exactly once."""
+    config = get_mock_registry().get_mock_config(name)
+    if config is None:
+        raise AssertionError(f"No mock registered for '{name}'")
+    if config.call_count != 1:
+        error_msg = msg or f"Expected '{name}' to be called once, but it was called {config.call_count} times"
+        raise AssertionError(error_msg)
+
+
+def assert_called_with(name: str, *args, **kwargs):
+    """Assert that a mocked function was called with specific arguments."""
+    config = get_mock_registry().get_mock_config(name)
+    if config is None:
+        raise AssertionError(f"No mock registered for '{name}'")
+    if not config.calls:
+        raise AssertionError(f"Expected '{name}' to be called, but it was not")
+
+    last_call = config.calls[-1]
+    if last_call.args != args or last_call.kwargs != kwargs:
+        raise AssertionError(
+            f"Expected '{name}' to be called with args={args}, kwargs={kwargs}, "
+            f"but was called with args={last_call.args}, kwargs={last_call.kwargs}"
+        )
+
+
+def get_call_count(name: str) -> int:
+    """Get the number of times a mocked function was called."""
+    config = get_mock_registry().get_mock_config(name)
+    if config is None:
+        return 0
+    return config.call_count
+
+
+def get_calls(name: str) -> List[MockCall]:
+    """Get all calls made to a mocked function."""
+    config = get_mock_registry().get_mock_config(name)
+    if config is None:
+        return []
+    return config.calls

--- a/pzspec/zig_ffi.py
+++ b/pzspec/zig_ffi.py
@@ -113,21 +113,31 @@ class ZigLibrary:
     def get_function(self, name: str, argtypes: list, restype: Any) -> Callable:
         """
         Get a function from the Zig library with proper type annotations.
-        
+
         Args:
             name: Function name as exported from Zig
             argtypes: List of ctypes types for arguments
             restype: Return type (ctypes type)
-        
+
         Returns:
             Callable function that can be invoked
+
+        Note:
+            If the function is currently mocked (via mock_zig_function),
+            a mock wrapper is returned instead of the actual function.
         """
+        # Check if function is mocked
+        from .mock import get_mock_registry, MockFunction
+        registry = get_mock_registry()
+        if registry.is_mocked(name):
+            return MockFunction(name, argtypes, restype)
+
         if name not in self._functions:
             func = getattr(self._lib, name)
             func.argtypes = argtypes
             func.restype = restype
             self._functions[name] = func
-        
+
         return self._functions[name]
     
     # Convenience methods for common types

--- a/usage/payment_service/.pzspec
+++ b/usage/payment_service/.pzspec
@@ -1,0 +1,6 @@
+{
+  "library_name": "payment_service",
+  "source_file": "src/payment.zig",
+  "optimize": "ReleaseSafe",
+  "build_dir": "zig-out/lib"
+}

--- a/usage/payment_service/build.zig
+++ b/usage/payment_service/build.zig
@@ -1,0 +1,25 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    // Create a module from the source file with target
+    const lib_module = b.addModule("payment_service", .{
+        .root_source_file = b.path("src/payment.zig"),
+        .target = target,
+    });
+
+    // Create a shared library that can be loaded by Python via FFI
+    const lib = b.addLibrary(.{
+        .name = "payment_service",
+        .root_module = lib_module,
+    });
+    lib.root_module.optimize = optimize;
+
+    // Set to dynamic linkage for shared library
+    lib.linkage = .dynamic;
+
+    // Install the library
+    b.installArtifact(lib);
+}

--- a/usage/payment_service/pzspec/__init__.py
+++ b/usage/payment_service/pzspec/__init__.py
@@ -1,0 +1,1 @@
+# PZSpec test directory for payment_service project

--- a/usage/payment_service/pzspec/test_payment.py
+++ b/usage/payment_service/pzspec/test_payment.py
@@ -1,0 +1,408 @@
+"""
+Test suite for Payment Service demonstrating PZSpec Mocking.
+
+This example shows how to use mock_zig_function() to test business logic
+by mocking external service calls at the FFI layer.
+
+IMPORTANT: Mocking works at the Python/FFI boundary. When Python calls
+a Zig function through get_function(), the mock intercepts it. Internal
+Zig-to-Zig calls cannot be mocked.
+
+Best practice: Design your system so that external service calls are
+made from Python, allowing you to mock them during tests.
+"""
+
+import sys
+from pathlib import Path
+
+# Add the parent PZSpec to the path
+project_root = Path(__file__).parent.parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+# Import from the framework package
+from pzspec.zig_ffi import ZigLibrary
+from pzspec.dsl import describe, it, expect
+from pzspec.mock import (
+    mock_zig_function,
+    assert_called,
+    assert_called_once,
+    get_call_count,
+    get_calls,
+)
+import ctypes
+
+# Load the Zig library (auto-builds if needed)
+zig = ZigLibrary()
+
+
+# =============================================================================
+# Helper Functions - Direct Zig Calls
+# =============================================================================
+def call_payment_gateway(amount_cents: int, card_token: str) -> int:
+    """Call payment gateway."""
+    func = zig.get_function(
+        "call_payment_gateway",
+        [ctypes.c_int32, ctypes.c_char_p],
+        ctypes.c_int32,
+    )
+    return func(amount_cents, card_token.encode("utf-8"))
+
+
+def check_fraud_score(user_id: int, amount_cents: int) -> int:
+    """Check fraud score."""
+    func = zig.get_function(
+        "check_fraud_score",
+        [ctypes.c_uint32, ctypes.c_int32],
+        ctypes.c_int32,
+    )
+    return func(user_id, amount_cents)
+
+
+def check_inventory(product_id: int, quantity: int) -> int:
+    """Check inventory availability."""
+    func = zig.get_function(
+        "check_inventory",
+        [ctypes.c_uint32, ctypes.c_uint32],
+        ctypes.c_uint32,
+    )
+    return func(product_id, quantity)
+
+
+def send_notification(user_id: int, message_type: int) -> int:
+    """Send notification."""
+    func = zig.get_function(
+        "send_notification",
+        [ctypes.c_uint32, ctypes.c_int32],
+        ctypes.c_int32,
+    )
+    return func(user_id, message_type)
+
+
+def call_external_api(endpoint_id: int, payload_size: int) -> int:
+    """Call external API."""
+    func = zig.get_function(
+        "call_external_api",
+        [ctypes.c_int32, ctypes.c_int32],
+        ctypes.c_int32,
+    )
+    return func(endpoint_id, payload_size)
+
+
+def calculate_total(subtotal_cents: int, tax_rate_bps: int) -> int:
+    """Calculate total with tax."""
+    func = zig.get_function("calculate_total", [ctypes.c_int32, ctypes.c_int32], ctypes.c_int32)
+    return func(subtotal_cents, tax_rate_bps)
+
+
+def apply_discount(amount_cents: int, discount_percent: int) -> int:
+    """Apply discount to amount."""
+    func = zig.get_function("apply_discount", [ctypes.c_int32, ctypes.c_int32], ctypes.c_int32)
+    return func(amount_cents, discount_percent)
+
+
+# =============================================================================
+# Python-side Business Logic (orchestrates Zig calls - mockable)
+# =============================================================================
+def process_payment(user_id: int, product_id: int, quantity: int, amount_cents: int, card_token: str) -> int:
+    """
+    Process a payment - Python orchestrates the external service calls.
+
+    This design allows us to mock individual Zig functions since Python
+    makes each call through get_function().
+
+    Returns:
+        0 = success
+        -1 = gateway timeout
+        -2 = gateway declined
+        -3 = fraud detected
+        -4 = insufficient inventory
+        -5 = invalid amount
+    """
+    # Validate amount
+    if amount_cents <= 0:
+        return -5  # invalid amount
+
+    # Check fraud
+    fraud_result = check_fraud_score(user_id, amount_cents)
+    if fraud_result == -1:
+        return -3  # fraud detected
+
+    # Check inventory
+    available = check_inventory(product_id, quantity)
+    if available < quantity:
+        return -4  # insufficient inventory
+
+    # Call payment gateway
+    gateway_result = call_payment_gateway(amount_cents, card_token)
+    if gateway_result == -1:
+        return -1  # gateway timeout
+    if gateway_result == 0:
+        return -2  # gateway declined
+
+    # Success - send notification
+    send_notification(user_id, 1)
+    return 0  # success
+
+
+def process_payment_with_retry(
+    user_id: int, product_id: int, quantity: int, amount_cents: int, card_token: str, max_retries: int
+) -> int:
+    """Process payment with retry logic on gateway timeout."""
+    if amount_cents <= 0:
+        return -5
+
+    fraud_result = check_fraud_score(user_id, amount_cents)
+    if fraud_result == -1:
+        return -3
+
+    available = check_inventory(product_id, quantity)
+    if available < quantity:
+        return -4
+
+    # Try gateway with retries
+    for _ in range(max_retries + 1):
+        gateway_result = call_payment_gateway(amount_cents, card_token)
+        if gateway_result == 1:
+            send_notification(user_id, 1)
+            return 0  # success
+        if gateway_result == 0:
+            return -2  # declined - don't retry
+        # gateway_result == -1 means timeout, retry
+
+    return -1  # exhausted retries
+
+
+# =============================================================================
+# Tests Without Mocking (pure business logic)
+# =============================================================================
+
+with describe("Payment Calculations (no mocking needed)"):
+
+    @it("should calculate total with tax")
+    def test_calculate_total():
+        # 1000 cents ($10.00) with 8.25% tax (825 basis points)
+        result = calculate_total(1000, 825)
+        expect(result).to_equal(1082)
+
+    @it("should apply percentage discount")
+    def test_apply_discount():
+        result = apply_discount(1000, 20)
+        expect(result).to_equal(800)
+
+    @it("should reject invalid discount")
+    def test_invalid_discount():
+        expect(apply_discount(1000, 0)).to_equal(1000)
+        expect(apply_discount(1000, -10)).to_equal(1000)
+        expect(apply_discount(1000, 150)).to_equal(1000)
+
+
+# =============================================================================
+# Tests With Mocking - Fixed Return Values
+# =============================================================================
+
+with describe("Payment Processing - Mocking External Services"):
+
+    @it("should succeed when all services return success")
+    def test_successful_payment():
+        with mock_zig_function("check_fraud_score", returns=1):  # safe
+            with mock_zig_function("check_inventory", returns=5):  # available
+                with mock_zig_function("call_payment_gateway", returns=1):  # approved
+                    with mock_zig_function("send_notification", returns=1):
+                        result = process_payment(123, 456, 2, 5000, "tok_visa")
+                        expect(result).to_equal(0)  # success
+
+    @it("should fail when fraud is detected")
+    def test_fraud_detected():
+        with mock_zig_function("check_fraud_score", returns=-1):  # fraud
+            result = process_payment(123, 456, 1, 5000, "tok_stolen")
+            expect(result).to_equal(-3)  # fraud detected
+
+    @it("should fail when inventory is insufficient")
+    def test_insufficient_inventory():
+        with mock_zig_function("check_fraud_score", returns=1):
+            with mock_zig_function("check_inventory", returns=2):  # only 2 available
+                result = process_payment(123, 456, 5, 5000, "tok_visa")
+                expect(result).to_equal(-4)  # insufficient inventory
+
+    @it("should fail when payment gateway times out")
+    def test_gateway_timeout():
+        with mock_zig_function("check_fraud_score", returns=1):
+            with mock_zig_function("check_inventory", returns=10):
+                with mock_zig_function("call_payment_gateway", returns=-1):  # timeout
+                    result = process_payment(123, 456, 1, 5000, "tok_visa")
+                    expect(result).to_equal(-1)  # gateway timeout
+
+    @it("should fail when payment is declined")
+    def test_gateway_declined():
+        with mock_zig_function("check_fraud_score", returns=1):
+            with mock_zig_function("check_inventory", returns=10):
+                with mock_zig_function("call_payment_gateway", returns=0):  # declined
+                    result = process_payment(123, 456, 1, 5000, "tok_declined")
+                    expect(result).to_equal(-2)  # gateway declined
+
+
+# =============================================================================
+# Tests With Mocking - Sequential Return Values (Retry Logic)
+# =============================================================================
+
+with describe("Payment Retry Logic - Sequential Mocking"):
+
+    @it("should succeed after retrying on timeout")
+    def test_retry_success():
+        with mock_zig_function("check_fraud_score", returns=1):
+            with mock_zig_function("check_inventory", returns=10):
+                # First two calls timeout, third succeeds
+                with mock_zig_function("call_payment_gateway", returns_sequence=[-1, -1, 1]):
+                    with mock_zig_function("send_notification", returns=1):
+                        result = process_payment_with_retry(123, 456, 1, 5000, "tok_visa", 3)
+                        expect(result).to_equal(0)  # success
+
+    @it("should fail after exhausting all retries")
+    def test_retry_exhausted():
+        with mock_zig_function("check_fraud_score", returns=1):
+            with mock_zig_function("check_inventory", returns=10):
+                # All calls timeout
+                with mock_zig_function("call_payment_gateway", returns_sequence=[-1, -1, -1, -1]) as mock:
+                    result = process_payment_with_retry(123, 456, 1, 5000, "tok_visa", 2)
+                    expect(result).to_equal(-1)  # timeout
+                    expect(mock.call_count).to_equal(3)  # initial + 2 retries
+
+    @it("should not retry on decline")
+    def test_no_retry_on_decline():
+        with mock_zig_function("check_fraud_score", returns=1):
+            with mock_zig_function("check_inventory", returns=10):
+                with mock_zig_function("call_payment_gateway", returns_sequence=[0, 1, 1]) as mock:
+                    result = process_payment_with_retry(123, 456, 1, 5000, "tok_declined", 3)
+                    expect(result).to_equal(-2)  # declined
+                    expect(mock.call_count).to_equal(1)  # only one attempt
+
+
+# =============================================================================
+# Tests With Mocking - Side Effects (Custom Logic)
+# =============================================================================
+
+with describe("Payment Processing - Side Effect Mocking"):
+
+    @it("should use custom side effect for fraud scoring")
+    def test_fraud_side_effect():
+        def custom_fraud_check(user_id, amount_cents):
+            if user_id == 666:
+                return -1  # fraud
+            return 1  # safe
+
+        with mock_zig_function("check_fraud_score", side_effect=custom_fraud_check):
+            with mock_zig_function("check_inventory", returns=10):
+                with mock_zig_function("call_payment_gateway", returns=1):
+                    with mock_zig_function("send_notification", returns=1):
+                        # Normal user succeeds
+                        result1 = process_payment(123, 456, 1, 5000, "tok_visa")
+                        expect(result1).to_equal(0)
+
+                        # Suspicious user fails
+                        result2 = process_payment(666, 456, 1, 5000, "tok_visa")
+                        expect(result2).to_equal(-3)
+
+    @it("should use side effect for dynamic gateway responses")
+    def test_gateway_side_effect():
+        call_count = [0]
+
+        def flaky_gateway(amount, token):
+            call_count[0] += 1
+            # Fail first 2 calls, then succeed
+            if call_count[0] <= 2:
+                return -1
+            return 1
+
+        with mock_zig_function("check_fraud_score", returns=1):
+            with mock_zig_function("check_inventory", returns=10):
+                with mock_zig_function("call_payment_gateway", side_effect=flaky_gateway):
+                    with mock_zig_function("send_notification", returns=1):
+                        result = process_payment_with_retry(123, 456, 1, 5000, "tok_visa", 3)
+                        expect(result).to_equal(0)
+                        expect(call_count[0]).to_equal(3)
+
+
+# =============================================================================
+# Tests With Mocking - Call Tracking and Assertions
+# =============================================================================
+
+with describe("Mock Call Tracking"):
+
+    @it("should track that notification was sent on success")
+    def test_notification_sent():
+        with mock_zig_function("check_fraud_score", returns=1):
+            with mock_zig_function("check_inventory", returns=10):
+                with mock_zig_function("call_payment_gateway", returns=1):
+                    with mock_zig_function("send_notification", returns=1) as mock:
+                        result = process_payment(123, 456, 1, 5000, "tok_visa")
+                        expect(result).to_equal(0)
+                        assert_called("send_notification")
+                        assert_called_once("send_notification")
+                        expect(mock.call_count).to_equal(1)
+
+    @it("should not send notification on failure")
+    def test_notification_not_sent_on_failure():
+        with mock_zig_function("check_fraud_score", returns=-1):
+            with mock_zig_function("send_notification", returns=1) as mock:
+                result = process_payment(123, 456, 1, 5000, "tok_visa")
+                expect(result).to_equal(-3)
+                expect(mock.call_count).to_equal(0)
+
+    @it("should track multiple gateway calls during retry")
+    def test_track_retry_calls():
+        with mock_zig_function("check_fraud_score", returns=1):
+            with mock_zig_function("check_inventory", returns=10):
+                with mock_zig_function("call_payment_gateway", returns_sequence=[-1, -1, 1]):
+                    with mock_zig_function("send_notification", returns=1):
+                        result = process_payment_with_retry(123, 456, 1, 5000, "tok_visa", 3)
+                        expect(result).to_equal(0)
+                        expect(get_call_count("call_payment_gateway")).to_equal(3)
+
+    @it("should access call arguments")
+    def test_call_arguments():
+        with mock_zig_function("check_fraud_score", returns=1):
+            with mock_zig_function("check_inventory", returns=10):
+                with mock_zig_function("call_payment_gateway", returns=1):
+                    with mock_zig_function("send_notification", returns=1):
+                        process_payment(123, 456, 1, 9999, "tok_visa")
+
+                        calls = get_calls("check_fraud_score")
+                        expect(len(calls)).to_equal(1)
+                        expect(calls[0].args[0]).to_equal(123)  # user_id
+                        expect(calls[0].args[1]).to_equal(9999)  # amount
+
+
+# =============================================================================
+# Tests - Direct Function Mocking (simpler examples)
+# =============================================================================
+
+with describe("Direct Function Mocking"):
+
+    @it("should mock function with fixed return value")
+    def test_mock_fixed_return():
+        # Mock returns a fixed value regardless of inputs
+        with mock_zig_function("call_external_api", returns=500):
+            result1 = call_external_api(0, 100)
+            result2 = call_external_api(99, 999)
+            expect(result1).to_equal(500)
+            expect(result2).to_equal(500)
+
+    @it("should mock with sequence for pagination")
+    def test_mock_pagination():
+        # Simulate paginated API responses
+        with mock_zig_function("call_external_api", returns_sequence=[200, 200, 404]):
+            expect(call_external_api(1, 0)).to_equal(200)  # page 1
+            expect(call_external_api(2, 0)).to_equal(200)  # page 2
+            expect(call_external_api(3, 0)).to_equal(404)  # no more pages
+
+    @it("should restore original behavior after mock context exits")
+    def test_mock_context_cleanup():
+        # Inside mock context
+        with mock_zig_function("check_fraud_score", returns=99):
+            mocked = check_fraud_score(1, 1000)
+            expect(mocked).to_equal(99)
+
+        # Outside mock context - back to real implementation
+        # Real implementation returns 1 for amounts <= 100000
+        real = check_fraud_score(1, 1000)
+        expect(real).to_equal(1)  # safe (real implementation)

--- a/usage/payment_service/run_tests.py
+++ b/usage/payment_service/run_tests.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""
+Run tests for the Payment Service example project.
+
+This demonstrates using PZSpec's mocking capabilities to test
+business logic in isolation by mocking external service calls.
+"""
+
+import sys
+from pathlib import Path
+
+# Add the parent PZSpec to the path
+project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+from pzspec.cli import run_tests
+
+
+if __name__ == "__main__":
+    success = run_tests(project_root=Path(__file__).parent)
+    sys.exit(0 if success else 1)

--- a/usage/payment_service/src/payment.zig
+++ b/usage/payment_service/src/payment.zig
@@ -1,0 +1,121 @@
+const std = @import("std");
+
+// =============================================================================
+// Payment Service - Example for Mocking External Dependencies
+// =============================================================================
+// This example demonstrates functions that can be mocked at the FFI layer.
+// Each function represents an "external service" that we want to mock in tests.
+
+// =============================================================================
+// Status Codes
+// =============================================================================
+
+pub const PaymentStatus = enum(i32) {
+    Success = 0,
+    GatewayTimeout = -1,
+    GatewayDeclined = -2,
+    FraudDetected = -3,
+    InsufficientInventory = -4,
+    InvalidAmount = -5,
+};
+
+// =============================================================================
+// External Service Calls (these are the functions we mock in tests)
+// =============================================================================
+
+/// Simulates calling an external payment gateway
+/// Returns: 1 = approved, 0 = declined, -1 = timeout/error
+export fn call_payment_gateway(amount_cents: i32, card_token: [*:0]const u8) i32 {
+    // In production, this would make an HTTP call to Stripe/PayPal/etc.
+    _ = card_token;
+
+    // Simulate different scenarios based on amount
+    if (amount_cents < 0) return -1; // error
+    if (amount_cents > 1000000) return 0; // decline large amounts
+    return 1; // approve
+}
+
+/// Simulates calling a fraud detection service
+/// Returns: 1 = safe, 0 = suspicious, -1 = definitely fraud
+export fn check_fraud_score(user_id: u32, amount_cents: i32) i32 {
+    // In production, this would call a fraud detection API
+    _ = user_id;
+
+    // Simulate: flag very large transactions as suspicious
+    if (amount_cents > 500000) return -1;
+    if (amount_cents > 100000) return 0;
+    return 1;
+}
+
+/// Simulates checking inventory availability
+/// Returns: available quantity (0 if not available)
+export fn check_inventory(product_id: u32, quantity: u32) u32 {
+    // In production, this would query a database/service
+    _ = product_id;
+
+    // Simulate: always have 10 in stock
+    if (quantity <= 10) return quantity;
+    return 10;
+}
+
+/// Simulates sending a notification
+/// Returns: 1 = sent, 0 = failed
+export fn send_notification(user_id: u32, message_type: i32) i32 {
+    // In production, this would send email/SMS/push
+    _ = user_id;
+    _ = message_type;
+    return 1;
+}
+
+/// Simulates an external API call that might be slow or fail
+/// Returns: response code (positive = success, negative = error)
+export fn call_external_api(endpoint_id: i32, payload_size: i32) i32 {
+    _ = payload_size;
+    // Simulate: endpoint 0 always succeeds, others may fail
+    if (endpoint_id == 0) return 200;
+    if (endpoint_id < 0) return -1;
+    return 200;
+}
+
+// =============================================================================
+// Pure Business Logic (no external calls - don't need mocking)
+// =============================================================================
+
+/// Calculate total with tax
+export fn calculate_total(subtotal_cents: i32, tax_rate_bps: i32) i32 {
+    // tax_rate_bps is in basis points (100 = 1%)
+    const tax = @divTrunc(subtotal_cents * tax_rate_bps, 10000);
+    return subtotal_cents + tax;
+}
+
+/// Apply discount code
+/// Returns discounted amount or original if invalid code
+export fn apply_discount(amount_cents: i32, discount_percent: i32) i32 {
+    if (discount_percent <= 0 or discount_percent > 100) {
+        return amount_cents;
+    }
+    const discount = @divTrunc(amount_cents * discount_percent, 100);
+    return amount_cents - discount;
+}
+
+/// Validate payment amount
+export fn validate_amount(amount_cents: i32) bool {
+    return amount_cents > 0 and amount_cents <= 10000000; // max $100,000
+}
+
+/// Calculate shipping cost based on weight
+export fn calculate_shipping(weight_grams: i32, distance_km: i32) i32 {
+    if (weight_grams <= 0 or distance_km <= 0) return 0;
+
+    // Base rate + weight factor + distance factor
+    const base = 500; // $5.00 base
+    const weight_cost = @divTrunc(weight_grams * 10, 1000); // $0.01 per gram
+    const distance_cost = @divTrunc(distance_km * 5, 100); // $0.05 per km
+
+    return base + weight_cost + distance_cost;
+}
+
+/// Check if amount qualifies for free shipping
+export fn qualifies_for_free_shipping(amount_cents: i32) bool {
+    return amount_cents >= 5000; // Free shipping over $50
+}


### PR DESCRIPTION
## Summary
- Adds `mock_zig_function()` context manager for mocking Zig functions
- Supports fixed return values: `returns=value`
- Supports sequential return values: `returns_sequence=[val1, val2, ...]`
- Supports side effects: `side_effect=callable`
- Call tracking with assertion helpers
- Includes `usage/payment_service` example project with 20 tests

## Usage Examples
```python
from pzspec import mock_zig_function, assert_called, get_call_count

with describe("Payment processing"):

    @it("should handle payment gateway timeout")
    def test_timeout():
        with mock_zig_function("payment_gateway_call", returns=-1):
            result = process_payment(100)
            expect(result.status).to_equal("timeout")
            assert_called("payment_gateway_call")

    @it("should retry on failure")
    def test_retry():
        with mock_zig_function("external_api", returns_sequence=[False, False, True]):
            result = call_with_retry()
            expect(get_call_count("external_api")).to_equal(3)

    @it("should compute with custom logic")
    def test_custom():
        def double(x):
            return x * 2

        with mock_zig_function("compute", side_effect=double):
            result = zig.get_function("compute", [c_int32], c_int32)(21)
            expect(result).to_equal(42)
```

## Limitations
- Mocks only work for functions accessed through `ZigLibrary.get_function()`
- Cannot mock internal Zig-to-Zig calls
- Functions must be retrieved AFTER entering the mock context

## Test plan
- [x] Test fixed return values
- [x] Test sequential return values
- [x] Test side effects
- [x] Test call count tracking
- [x] Test assertion helpers
- [x] All 20 tests in usage/payment_service pass

Closes #10