### PR TITLE
Add sentinel value helpers for FFI patterns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,7 @@ jobs:
       - name: Run memory_tracking tests (leak detection)
         working-directory: usage/memory_tracking
         run: pzspec
+
+      - name: Run ecs_entities tests (sentinel values)
+        working-directory: usage/ecs_entities
+        run: pzspec

--- a/pzspec/__init__.py
+++ b/pzspec/__init__.py
@@ -49,6 +49,12 @@ from .memory import (
     assert_no_leaks,
     MemoryLeakError,
 )
+from .sentinel import (
+    Sentinel,
+    NO_ENTITY,
+    NO_INDEX,
+    INVALID_ID,
+)
 
 # CLI is available but not exported by default
 # Access via: from pzspec.cli import main
@@ -93,6 +99,10 @@ __all__ = [
     "check_leaks",
     "assert_no_leaks",
     "MemoryLeakError",
+    "Sentinel",
+    "NO_ENTITY",
+    "NO_INDEX",
+    "INVALID_ID",
 ]
 
 __version__ = "0.1.0"

--- a/pzspec/sentinel.py
+++ b/pzspec/sentinel.py
@@ -1,0 +1,209 @@
+"""
+Sentinel value helpers for FFI patterns.
+
+When working with Zig code through FFI, certain values like "null" or "no entity"
+cannot be represented directly. This module provides helpers for working with
+sentinel values - special values that represent the absence of a valid value.
+
+Common use cases:
+- Entity IDs where 0 is valid (ECS systems)
+- Optional numeric returns
+- Error indicators in return values
+
+Zig Side Example:
+-----------------
+```zig
+const std = @import("std");
+
+// Define sentinel as maximum value (can't be a valid entity index)
+pub const NO_ENTITY: u32 = std.math.maxInt(u32);  // 0xFFFFFFFF
+
+// Export for Python to retrieve
+export fn get_no_entity_sentinel() u32 {
+    return NO_ENTITY;
+}
+
+// Use in functions that may not find an entity
+export fn find_entity_by_name(name: [*:0]const u8) u32 {
+    // ... search logic ...
+    if (found) {
+        return entity.id;
+    }
+    return NO_ENTITY;  // Not found
+}
+```
+
+Python Side Example:
+--------------------
+```python
+from pzspec import ZigLibrary, Sentinel
+import ctypes
+
+zig = ZigLibrary()
+
+# Create a sentinel for entity IDs
+NO_ENTITY = Sentinel.from_zig_function(zig, "get_no_entity_sentinel", ctypes.c_uint32)
+
+# Use in tests
+entity_id = zig.get_function("find_entity_by_name", [ctypes.c_char_p], ctypes.c_uint32)(b"player")
+
+if NO_ENTITY.is_valid(entity_id):
+    # Found the entity
+    process_entity(entity_id)
+else:
+    # Not found
+    handle_missing()
+
+# Or use expect() assertions
+expect(entity_id).to_not_be_sentinel(NO_ENTITY)
+```
+"""
+
+import ctypes
+from typing import Any, Optional, Union
+from dataclasses import dataclass
+
+
+@dataclass
+class Sentinel:
+    """
+    Represents a sentinel value for FFI optional/nullable patterns.
+
+    A sentinel is a special value that indicates "no value" or "invalid"
+    when the type doesn't have a natural null representation.
+    """
+    value: Any
+    name: str = "SENTINEL"
+    description: str = ""
+
+    def is_sentinel(self, val: Any) -> bool:
+        """Check if a value equals this sentinel."""
+        return val == self.value
+
+    def is_valid(self, val: Any) -> bool:
+        """Check if a value is NOT the sentinel (i.e., is valid)."""
+        return val != self.value
+
+    def __eq__(self, other: Any) -> bool:
+        """Allow direct comparison with values."""
+        if isinstance(other, Sentinel):
+            return self.value == other.value
+        return self.value == other
+
+    def __hash__(self) -> int:
+        return hash(self.value)
+
+    def __repr__(self) -> str:
+        return f"Sentinel({self.name}={self.value})"
+
+    @classmethod
+    def from_zig_function(
+        cls,
+        zig_lib,
+        func_name: str,
+        restype: Any,
+        name: Optional[str] = None,
+        description: str = ""
+    ) -> "Sentinel":
+        """
+        Create a Sentinel by calling a Zig export function.
+
+        Args:
+            zig_lib: ZigLibrary instance
+            func_name: Name of the Zig function that returns the sentinel value
+            restype: ctypes return type (e.g., ctypes.c_uint32)
+            name: Optional name for the sentinel (defaults to func_name)
+            description: Optional description
+
+        Returns:
+            Sentinel with the value from the Zig function
+
+        Example:
+            NO_ENTITY = Sentinel.from_zig_function(zig, "get_no_entity_sentinel", c_uint32)
+        """
+        func = zig_lib.get_function(func_name, [], restype)
+        value = func()
+        return cls(
+            value=value,
+            name=name or func_name.replace("get_", "").replace("_sentinel", "").upper(),
+            description=description
+        )
+
+    @classmethod
+    def max_uint32(cls, name: str = "NO_VALUE") -> "Sentinel":
+        """Create a sentinel using max u32 value (0xFFFFFFFF)."""
+        return cls(value=0xFFFFFFFF, name=name, description="Maximum u32 value")
+
+    @classmethod
+    def max_uint64(cls, name: str = "NO_VALUE") -> "Sentinel":
+        """Create a sentinel using max u64 value."""
+        return cls(value=0xFFFFFFFFFFFFFFFF, name=name, description="Maximum u64 value")
+
+    @classmethod
+    def max_int32(cls, name: str = "NO_VALUE") -> "Sentinel":
+        """Create a sentinel using max i32 value (0x7FFFFFFF)."""
+        return cls(value=0x7FFFFFFF, name=name, description="Maximum i32 value")
+
+    @classmethod
+    def min_int32(cls, name: str = "NO_VALUE") -> "Sentinel":
+        """Create a sentinel using min i32 value (-2147483648)."""
+        return cls(value=-2147483648, name=name, description="Minimum i32 value")
+
+    @classmethod
+    def negative_one(cls, name: str = "NO_VALUE") -> "Sentinel":
+        """Create a sentinel using -1 (common for "not found" returns)."""
+        return cls(value=-1, name=name, description="Negative one (-1)")
+
+
+# Common pre-defined sentinels
+NO_ENTITY = Sentinel.max_uint32("NO_ENTITY")
+NO_INDEX = Sentinel.negative_one("NO_INDEX")
+INVALID_ID = Sentinel.max_uint32("INVALID_ID")
+
+
+def add_sentinel_assertions(expectation_class):
+    """
+    Add sentinel-related assertion methods to an Expectation class.
+
+    This is called automatically when pzspec is imported.
+    """
+
+    def to_be_sentinel(self, sentinel: Sentinel, msg: Optional[str] = None):
+        """Assert that the value IS the sentinel (no valid value)."""
+        if not sentinel.is_sentinel(self.actual):
+            error_msg = msg or f"Expected {sentinel.name} ({sentinel.value}), but got {self.actual}"
+            raise AssertionError(error_msg)
+
+    def to_not_be_sentinel(self, sentinel: Sentinel, msg: Optional[str] = None):
+        """Assert that the value is NOT the sentinel (has a valid value)."""
+        if sentinel.is_sentinel(self.actual):
+            error_msg = msg or f"Expected a valid value, but got {sentinel.name} ({sentinel.value})"
+            raise AssertionError(error_msg)
+
+    def to_be_valid(self, sentinel: Sentinel, msg: Optional[str] = None):
+        """Alias for to_not_be_sentinel - assert value is valid (not sentinel)."""
+        return self.to_not_be_sentinel(sentinel, msg)
+
+    def to_be_invalid(self, sentinel: Sentinel, msg: Optional[str] = None):
+        """Alias for to_be_sentinel - assert value is invalid (is sentinel)."""
+        return self.to_be_sentinel(sentinel, msg)
+
+    expectation_class.to_be_sentinel = to_be_sentinel
+    expectation_class.to_not_be_sentinel = to_not_be_sentinel
+    expectation_class.to_be_valid = to_be_valid
+    expectation_class.to_be_invalid = to_be_invalid
+
+    return expectation_class
+
+
+# Automatically add sentinel assertions to Expectation class
+def _init_sentinel_assertions():
+    """Initialize sentinel assertions on the Expectation class."""
+    try:
+        from .dsl import Expectation
+        add_sentinel_assertions(Expectation)
+    except ImportError:
+        pass  # Will be initialized later
+
+
+_init_sentinel_assertions()

--- a/usage/ecs_entities/.pzspec
+++ b/usage/ecs_entities/.pzspec
@@ -1,0 +1,6 @@
+{
+  "library_name": "ecs_entities",
+  "source_file": "src/entities.zig",
+  "optimize": "ReleaseSafe",
+  "build_dir": "zig-out/lib"
+}

--- a/usage/ecs_entities/build.zig
+++ b/usage/ecs_entities/build.zig
@@ -1,0 +1,25 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    // Create a module from the source file with target
+    const lib_module = b.addModule("ecs_entities", .{
+        .root_source_file = b.path("src/entities.zig"),
+        .target = target,
+    });
+
+    // Create a shared library that can be loaded by Python via FFI
+    const lib = b.addLibrary(.{
+        .name = "ecs_entities",
+        .root_module = lib_module,
+    });
+    lib.root_module.optimize = optimize;
+
+    // Set to dynamic linkage for shared library
+    lib.linkage = .dynamic;
+
+    // Install the library
+    b.installArtifact(lib);
+}

--- a/usage/ecs_entities/pzspec/__init__.py
+++ b/usage/ecs_entities/pzspec/__init__.py
@@ -1,0 +1,1 @@
+# PZSpec test directory for ecs_entities project

--- a/usage/ecs_entities/pzspec/test_entities.py
+++ b/usage/ecs_entities/pzspec/test_entities.py
@@ -1,0 +1,431 @@
+"""
+Test suite for ECS Entity System demonstrating PZSpec Sentinel values.
+
+This example shows how to use PZSpec's Sentinel class to handle FFI patterns
+where 0 is a valid value (like entity IDs) and you need special values to
+represent "no entity" or "not found".
+"""
+
+import sys
+from pathlib import Path
+
+# Add the parent PZSpec to the path
+project_root = Path(__file__).parent.parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+# Import from the framework package
+from pzspec.zig_ffi import ZigLibrary
+from pzspec.dsl import describe, it, expect, before_each
+from pzspec.sentinel import Sentinel, NO_ENTITY, NO_INDEX
+import ctypes
+
+# Load the Zig library (auto-builds if needed)
+zig = ZigLibrary()
+
+
+# =============================================================================
+# Sentinel Value Setup
+# =============================================================================
+# Option 1: Use pre-defined sentinels from pzspec (convenient defaults)
+# NO_ENTITY = Sentinel.max_uint32("NO_ENTITY")  # Already imported
+
+# Option 2: Get sentinel values directly from Zig (ensures consistency)
+NO_ENTITY_FROM_ZIG = Sentinel.from_zig_function(
+    zig, "get_no_entity_sentinel", ctypes.c_uint32, "NO_ENTITY"
+)
+
+NO_INDEX_FROM_ZIG = Sentinel.from_zig_function(
+    zig, "get_no_index_sentinel", ctypes.c_int32, "NO_INDEX"
+)
+
+INVALID_GENERATION = Sentinel.from_zig_function(
+    zig, "get_invalid_generation_sentinel", ctypes.c_uint32, "INVALID_GENERATION"
+)
+
+
+# =============================================================================
+# Helper Functions
+# =============================================================================
+def create_entity():
+    """Create a new entity and return its ID."""
+    func = zig.get_function("create_entity", [], ctypes.c_uint32)
+    return func()
+
+
+def create_named_entity(name: str):
+    """Create an entity with a name."""
+    func = zig.get_function("create_named_entity", [ctypes.c_char_p], ctypes.c_uint32)
+    return func(name.encode("utf-8"))
+
+
+def destroy_entity(entity_id: int):
+    """Destroy an entity."""
+    func = zig.get_function("destroy_entity", [ctypes.c_uint32], ctypes.c_bool)
+    return func(entity_id)
+
+
+def is_entity_alive(entity_id: int):
+    """Check if an entity is alive."""
+    func = zig.get_function("is_entity_alive", [ctypes.c_uint32], ctypes.c_bool)
+    return func(entity_id)
+
+
+def get_entity_count():
+    """Get the current entity count."""
+    func = zig.get_function("get_entity_count", [], ctypes.c_uint32)
+    return func()
+
+
+def reset_entities():
+    """Reset all entities (for test isolation)."""
+    func = zig.get_function("reset_entities", [], None)
+    func()
+
+
+def find_entity_by_name(name: str):
+    """Find an entity by name - returns NO_ENTITY if not found."""
+    func = zig.get_function("find_entity_by_name", [ctypes.c_char_p], ctypes.c_uint32)
+    return func(name.encode("utf-8"))
+
+
+def find_healthiest_entity():
+    """Find the entity with highest health - returns NO_ENTITY if none exist."""
+    func = zig.get_function("find_healthiest_entity", [], ctypes.c_uint32)
+    return func()
+
+
+def find_nearest_entity(x: float, y: float):
+    """Find nearest entity to position - returns NO_ENTITY if none exist."""
+    func = zig.get_function(
+        "find_nearest_entity", [ctypes.c_float, ctypes.c_float], ctypes.c_uint32
+    )
+    return func(x, y)
+
+
+def get_entity_parent(entity_id: int):
+    """Get entity's parent - returns NO_ENTITY if no parent."""
+    func = zig.get_function("get_entity_parent", [ctypes.c_uint32], ctypes.c_uint32)
+    return func(entity_id)
+
+
+def set_entity_parent(entity_id: int, parent_id: int):
+    """Set entity's parent."""
+    func = zig.get_function(
+        "set_entity_parent", [ctypes.c_uint32, ctypes.c_uint32], ctypes.c_bool
+    )
+    return func(entity_id, parent_id)
+
+
+def find_first_child(parent_id: int):
+    """Find first child of entity - returns NO_ENTITY if no children."""
+    func = zig.get_function("find_first_child", [ctypes.c_uint32], ctypes.c_uint32)
+    return func(parent_id)
+
+
+def get_entity_health(entity_id: int):
+    """Get entity health - returns NO_INDEX if entity doesn't exist."""
+    func = zig.get_function("get_entity_health", [ctypes.c_uint32], ctypes.c_int32)
+    return func(entity_id)
+
+
+def set_entity_health(entity_id: int, health: int):
+    """Set entity health."""
+    func = zig.get_function(
+        "set_entity_health", [ctypes.c_uint32, ctypes.c_int32], ctypes.c_bool
+    )
+    return func(entity_id, health)
+
+
+def set_entity_position(entity_id: int, x: float, y: float):
+    """Set entity position."""
+    func = zig.get_function(
+        "set_entity_position",
+        [ctypes.c_uint32, ctypes.c_float, ctypes.c_float],
+        ctypes.c_bool,
+    )
+    return func(entity_id, x, y)
+
+
+def get_entity_generation(entity_id: int):
+    """Get entity generation - returns INVALID_GENERATION if invalid."""
+    func = zig.get_function("get_entity_generation", [ctypes.c_uint32], ctypes.c_uint32)
+    return func(entity_id)
+
+
+# =============================================================================
+# Tests
+# =============================================================================
+
+with describe("Entity Creation"):
+    @before_each
+    def setup():
+        reset_entities()
+
+    @it("should create an entity with valid ID (starting from 0)")
+    def test_create_entity():
+        entity_id = create_entity()
+        # Entity ID 0 is valid - this is why we need sentinels!
+        expect(entity_id).to_equal(0)
+        expect(is_entity_alive(entity_id)).to_be_true()
+
+    @it("should create multiple entities with sequential IDs")
+    def test_create_multiple():
+        id1 = create_entity()
+        id2 = create_entity()
+        id3 = create_entity()
+
+        expect(id1).to_equal(0)
+        expect(id2).to_equal(1)
+        expect(id3).to_equal(2)
+        expect(get_entity_count()).to_equal(3)
+
+    @it("should create named entities")
+    def test_create_named():
+        player_id = create_named_entity("player")
+        enemy_id = create_named_entity("enemy")
+
+        # Both are valid entities (not sentinel values)
+        expect(player_id).to_not_be_sentinel(NO_ENTITY)
+        expect(enemy_id).to_not_be_sentinel(NO_ENTITY)
+        expect(player_id).to_not_equal(enemy_id)
+
+
+with describe("Sentinel Values - Finding Entities"):
+    @before_each
+    def setup():
+        reset_entities()
+
+    @it("should return NO_ENTITY when searching empty world")
+    def test_find_in_empty():
+        result = find_entity_by_name("player")
+
+        # Using sentinel assertions
+        expect(result).to_be_sentinel(NO_ENTITY)
+
+        # Equivalent check using is_sentinel method
+        expect(NO_ENTITY.is_sentinel(result)).to_be_true()
+
+        # Equivalent check using is_valid method
+        expect(NO_ENTITY.is_valid(result)).to_be_false()
+
+    @it("should return NO_ENTITY when entity not found by name")
+    def test_find_nonexistent():
+        create_named_entity("player")
+        create_named_entity("enemy")
+
+        result = find_entity_by_name("boss")  # doesn't exist
+
+        expect(result).to_be_sentinel(NO_ENTITY)
+
+    @it("should return valid ID when entity found")
+    def test_find_existing():
+        create_named_entity("player")
+        enemy_id = create_named_entity("enemy")
+        create_named_entity("ally")
+
+        result = find_entity_by_name("enemy")
+
+        expect(result).to_not_be_sentinel(NO_ENTITY)
+        expect(result).to_equal(enemy_id)
+
+    @it("should return NO_ENTITY when finding healthiest in empty world")
+    def test_healthiest_empty():
+        result = find_healthiest_entity()
+        expect(result).to_be_sentinel(NO_ENTITY)
+
+    @it("should find healthiest entity when entities exist")
+    def test_healthiest_exists():
+        e1 = create_entity()
+        e2 = create_entity()
+        e3 = create_entity()
+
+        set_entity_health(e1, 50)
+        set_entity_health(e2, 100)  # healthiest
+        set_entity_health(e3, 75)
+
+        result = find_healthiest_entity()
+
+        expect(result).to_not_be_sentinel(NO_ENTITY)
+        expect(result).to_equal(e2)
+
+
+with describe("Sentinel Values - Parent/Child Relationships"):
+    @before_each
+    def setup():
+        reset_entities()
+
+    @it("should have NO_ENTITY as default parent")
+    def test_default_parent():
+        entity_id = create_entity()
+        parent = get_entity_parent(entity_id)
+
+        # Using to_be_invalid (alias for to_be_sentinel)
+        expect(parent).to_be_invalid(NO_ENTITY)
+
+    @it("should set and get valid parent")
+    def test_valid_parent():
+        parent_id = create_named_entity("parent")
+        child_id = create_named_entity("child")
+
+        success = set_entity_parent(child_id, parent_id)
+        expect(success).to_be_true()
+
+        result = get_entity_parent(child_id)
+        # Using to_be_valid (alias for to_not_be_sentinel)
+        expect(result).to_be_valid(NO_ENTITY)
+        expect(result).to_equal(parent_id)
+
+    @it("should return NO_ENTITY for child search on entity without children")
+    def test_no_children():
+        parent_id = create_entity()
+
+        result = find_first_child(parent_id)
+        expect(result).to_be_sentinel(NO_ENTITY)
+
+    @it("should find child when parent has children")
+    def test_has_children():
+        parent_id = create_named_entity("parent")
+        child_id = create_named_entity("child")
+        set_entity_parent(child_id, parent_id)
+
+        result = find_first_child(parent_id)
+        expect(result).to_not_be_sentinel(NO_ENTITY)
+        expect(result).to_equal(child_id)
+
+    @it("should orphan children when parent is destroyed")
+    def test_orphan_on_destroy():
+        parent_id = create_named_entity("parent")
+        child_id = create_named_entity("child")
+        set_entity_parent(child_id, parent_id)
+
+        # Verify parent is set
+        expect(get_entity_parent(child_id)).to_equal(parent_id)
+
+        # Destroy parent
+        destroy_entity(parent_id)
+
+        # Child should now have NO_ENTITY as parent
+        expect(get_entity_parent(child_id)).to_be_sentinel(NO_ENTITY)
+
+
+with describe("Sentinel Values - Component Access"):
+    @before_each
+    def setup():
+        reset_entities()
+
+    @it("should return NO_INDEX for health of non-existent entity")
+    def test_health_nonexistent():
+        # Entity 999 doesn't exist
+        health = get_entity_health(999)
+        expect(health).to_be_sentinel(NO_INDEX_FROM_ZIG)
+
+    @it("should return NO_INDEX for health when querying sentinel value")
+    def test_health_sentinel_query():
+        # Querying with NO_ENTITY should return NO_INDEX
+        health = get_entity_health(NO_ENTITY.value)
+        expect(health).to_be_sentinel(NO_INDEX_FROM_ZIG)
+
+    @it("should return valid health for existing entity")
+    def test_health_valid():
+        entity_id = create_entity()
+        set_entity_health(entity_id, 75)
+
+        health = get_entity_health(entity_id)
+        expect(health).to_not_be_sentinel(NO_INDEX_FROM_ZIG)
+        expect(health).to_equal(75)
+
+
+with describe("Sentinel Values - Generation/Staleness"):
+    @before_each
+    def setup():
+        reset_entities()
+
+    @it("should return INVALID_GENERATION for out-of-bounds entity")
+    def test_generation_invalid():
+        gen = get_entity_generation(NO_ENTITY.value)
+        expect(gen).to_be_sentinel(INVALID_GENERATION)
+
+    @it("should track generation across entity lifecycle")
+    def test_generation_lifecycle():
+        # Create entity at slot 0
+        e1 = create_entity()
+        gen1 = get_entity_generation(e1)
+        expect(gen1).to_equal(1)  # First use of this slot
+
+        # Destroy it
+        destroy_entity(e1)
+
+        # Create another entity (reuses slot 0)
+        e2 = create_entity()
+        expect(e2).to_equal(0)  # Same slot
+
+        gen2 = get_entity_generation(e2)
+        expect(gen2).to_equal(2)  # Generation increased
+
+
+with describe("Sentinel Comparison"):
+    @it("should allow direct comparison with sentinel values")
+    def test_direct_comparison():
+        reset_entities()
+        result = find_entity_by_name("nonexistent")
+
+        # Direct equality check works
+        expect(result == NO_ENTITY.value).to_be_true()
+        expect(result == NO_ENTITY).to_be_true()  # Sentinel.__eq__ supports this
+
+    @it("should verify Zig and Python sentinel values match")
+    def test_sentinel_values_match():
+        # The sentinel values from Zig should match our pre-defined ones
+        expect(NO_ENTITY_FROM_ZIG.value).to_equal(NO_ENTITY.value)
+        expect(NO_ENTITY_FROM_ZIG.value).to_equal(0xFFFFFFFF)
+
+        expect(NO_INDEX_FROM_ZIG.value).to_equal(NO_INDEX.value)
+        expect(NO_INDEX_FROM_ZIG.value).to_equal(-1)
+
+
+with describe("Real-World Patterns"):
+    @before_each
+    def setup():
+        reset_entities()
+
+    @it("should handle 'find or create' pattern safely")
+    def test_find_or_create():
+        """Common pattern: find entity by name, create if not found."""
+
+        def get_or_create_entity(name: str) -> int:
+            entity_id = find_entity_by_name(name)
+            if NO_ENTITY.is_sentinel(entity_id):
+                entity_id = create_named_entity(name)
+            return entity_id
+
+        # First call creates
+        player1 = get_or_create_entity("player")
+        expect(player1).to_not_be_sentinel(NO_ENTITY)
+
+        # Second call finds existing
+        player2 = get_or_create_entity("player")
+        expect(player2).to_equal(player1)
+
+        # Only one entity should exist
+        expect(get_entity_count()).to_equal(1)
+
+    @it("should handle parent chain traversal")
+    def test_parent_chain():
+        """Traverse up parent chain until we hit NO_ENTITY."""
+        root = create_named_entity("root")
+        child = create_named_entity("child")
+        grandchild = create_named_entity("grandchild")
+
+        set_entity_parent(child, root)
+        set_entity_parent(grandchild, child)
+
+        # Count ancestors
+        ancestors = []
+        current = get_entity_parent(grandchild)
+        while NO_ENTITY.is_valid(current):
+            ancestors.append(current)
+            current = get_entity_parent(current)
+
+        expect(len(ancestors)).to_equal(2)  # child and root
+        expect(ancestors[0]).to_equal(child)
+        expect(ancestors[1]).to_equal(root)

--- a/usage/ecs_entities/run_tests.py
+++ b/usage/ecs_entities/run_tests.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""
+Run tests for the ECS Entities example project.
+
+This demonstrates using PZSpec's Sentinel values for FFI patterns
+where 0 is a valid value (like entity IDs).
+"""
+
+import sys
+from pathlib import Path
+
+# Add the parent PZSpec to the path
+project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+from pzspec.cli import run_tests
+
+
+if __name__ == "__main__":
+    success = run_tests(project_root=Path(__file__).parent)
+    sys.exit(0 if success else 1)

--- a/usage/ecs_entities/src/entities.zig
+++ b/usage/ecs_entities/src/entities.zig
@@ -1,0 +1,346 @@
+const std = @import("std");
+
+// =============================================================================
+// Sentinel Values
+// =============================================================================
+// In ECS systems, entity IDs are typically indices (0, 1, 2, ...) where 0 is a
+// valid entity. We can't use 0 or null to indicate "no entity", so we use
+// sentinel values - special values that represent "no valid value".
+
+/// Sentinel value for "no entity" - maximum u32 value (can never be a valid index)
+pub const NO_ENTITY: u32 = std.math.maxInt(u32); // 0xFFFFFFFF
+
+/// Sentinel value for "no index" - commonly -1 for signed integers
+pub const NO_INDEX: i32 = -1;
+
+/// Sentinel value for "invalid generation" - used to detect stale references
+pub const INVALID_GENERATION: u32 = std.math.maxInt(u32);
+
+// Export sentinel getters for Python to retrieve the actual values
+export fn get_no_entity_sentinel() u32 {
+    return NO_ENTITY;
+}
+
+export fn get_no_index_sentinel() i32 {
+    return NO_INDEX;
+}
+
+export fn get_invalid_generation_sentinel() u32 {
+    return INVALID_GENERATION;
+}
+
+// =============================================================================
+// Entity System
+// =============================================================================
+
+/// Maximum number of entities in our simple ECS
+const MAX_ENTITIES: usize = 1000;
+
+/// Entity component data
+const EntityData = struct {
+    alive: bool = false,
+    generation: u32 = 0,
+    name: [32]u8 = [_]u8{0} ** 32,
+    health: i32 = 0,
+    position_x: f32 = 0.0,
+    position_y: f32 = 0.0,
+    parent: u32 = NO_ENTITY,
+};
+
+/// Global entity storage
+var entities: [MAX_ENTITIES]EntityData = [_]EntityData{.{}} ** MAX_ENTITIES;
+var entity_count: u32 = 0;
+
+/// Create a new entity and return its ID
+export fn create_entity() u32 {
+    if (entity_count >= MAX_ENTITIES) {
+        return NO_ENTITY; // No space left
+    }
+
+    // Find first free slot
+    for (&entities, 0..) |*entity, i| {
+        if (!entity.alive) {
+            entity.alive = true;
+            entity.generation += 1;
+            entity.health = 100;
+            entity.parent = NO_ENTITY;
+            entity_count += 1;
+            return @intCast(i);
+        }
+    }
+
+    return NO_ENTITY; // Should not reach here
+}
+
+/// Create an entity with a name
+export fn create_named_entity(name_ptr: [*:0]const u8) u32 {
+    const entity_id = create_entity();
+    if (entity_id == NO_ENTITY) {
+        return NO_ENTITY;
+    }
+
+    // Copy name into entity
+    var i: usize = 0;
+    while (name_ptr[i] != 0 and i < 31) : (i += 1) {
+        entities[entity_id].name[i] = name_ptr[i];
+    }
+    entities[entity_id].name[i] = 0;
+
+    return entity_id;
+}
+
+/// Destroy an entity
+export fn destroy_entity(entity_id: u32) bool {
+    if (entity_id >= MAX_ENTITIES or entity_id == NO_ENTITY) {
+        return false;
+    }
+
+    if (!entities[entity_id].alive) {
+        return false;
+    }
+
+    // Clear all children's parent references
+    for (&entities) |*entity| {
+        if (entity.alive and entity.parent == entity_id) {
+            entity.parent = NO_ENTITY;
+        }
+    }
+
+    entities[entity_id].alive = false;
+    entities[entity_id].name = [_]u8{0} ** 32;
+    entities[entity_id].health = 0;
+    entity_count -= 1;
+    return true;
+}
+
+/// Check if an entity is alive
+export fn is_entity_alive(entity_id: u32) bool {
+    if (entity_id >= MAX_ENTITIES or entity_id == NO_ENTITY) {
+        return false;
+    }
+    return entities[entity_id].alive;
+}
+
+/// Get entity count
+export fn get_entity_count() u32 {
+    return entity_count;
+}
+
+/// Reset all entities (for testing)
+export fn reset_entities() void {
+    for (&entities) |*entity| {
+        entity.* = .{};
+    }
+    entity_count = 0;
+}
+
+// =============================================================================
+// Entity Queries - Return sentinel values when not found
+// =============================================================================
+
+/// Find entity by name - returns NO_ENTITY if not found
+export fn find_entity_by_name(name_ptr: [*:0]const u8) u32 {
+    for (entities, 0..) |entity, i| {
+        if (entity.alive) {
+            // Compare names
+            var match = true;
+            var j: usize = 0;
+            while (name_ptr[j] != 0 and j < 31) : (j += 1) {
+                if (entity.name[j] != name_ptr[j]) {
+                    match = false;
+                    break;
+                }
+            }
+            if (match and entity.name[j] == 0) {
+                return @intCast(i);
+            }
+        }
+    }
+    return NO_ENTITY; // Not found
+}
+
+/// Find entity with highest health - returns NO_ENTITY if no entities exist
+export fn find_healthiest_entity() u32 {
+    var best_id: u32 = NO_ENTITY;
+    var best_health: i32 = std.math.minInt(i32);
+
+    for (entities, 0..) |entity, i| {
+        if (entity.alive and entity.health > best_health) {
+            best_health = entity.health;
+            best_id = @intCast(i);
+        }
+    }
+
+    return best_id;
+}
+
+/// Find nearest entity to a position - returns NO_ENTITY if no entities exist
+export fn find_nearest_entity(x: f32, y: f32) u32 {
+    var nearest_id: u32 = NO_ENTITY;
+    var nearest_dist: f32 = std.math.floatMax(f32);
+
+    for (entities, 0..) |entity, i| {
+        if (entity.alive) {
+            const dx = entity.position_x - x;
+            const dy = entity.position_y - y;
+            const dist = @sqrt(dx * dx + dy * dy);
+            if (dist < nearest_dist) {
+                nearest_dist = dist;
+                nearest_id = @intCast(i);
+            }
+        }
+    }
+
+    return nearest_id;
+}
+
+/// Get entity's parent - returns NO_ENTITY if no parent or invalid entity
+export fn get_entity_parent(entity_id: u32) u32 {
+    if (entity_id >= MAX_ENTITIES or entity_id == NO_ENTITY) {
+        return NO_ENTITY;
+    }
+    if (!entities[entity_id].alive) {
+        return NO_ENTITY;
+    }
+    return entities[entity_id].parent;
+}
+
+/// Set entity's parent - returns true on success
+export fn set_entity_parent(entity_id: u32, parent_id: u32) bool {
+    if (entity_id >= MAX_ENTITIES or entity_id == NO_ENTITY) {
+        return false;
+    }
+    if (!entities[entity_id].alive) {
+        return false;
+    }
+    // Parent can be NO_ENTITY (no parent) or a valid alive entity
+    if (parent_id != NO_ENTITY) {
+        if (parent_id >= MAX_ENTITIES or !entities[parent_id].alive) {
+            return false;
+        }
+        // Prevent self-parenting
+        if (parent_id == entity_id) {
+            return false;
+        }
+    }
+    entities[entity_id].parent = parent_id;
+    return true;
+}
+
+/// Find first child of an entity - returns NO_ENTITY if no children
+export fn find_first_child(parent_id: u32) u32 {
+    if (parent_id >= MAX_ENTITIES or parent_id == NO_ENTITY) {
+        return NO_ENTITY;
+    }
+
+    for (entities, 0..) |entity, i| {
+        if (entity.alive and entity.parent == parent_id) {
+            return @intCast(i);
+        }
+    }
+
+    return NO_ENTITY;
+}
+
+// =============================================================================
+// Component Access
+// =============================================================================
+
+/// Get entity health - returns NO_INDEX (-1) if entity doesn't exist
+export fn get_entity_health(entity_id: u32) i32 {
+    if (entity_id >= MAX_ENTITIES or entity_id == NO_ENTITY) {
+        return NO_INDEX;
+    }
+    if (!entities[entity_id].alive) {
+        return NO_INDEX;
+    }
+    return entities[entity_id].health;
+}
+
+/// Set entity health - returns true on success
+export fn set_entity_health(entity_id: u32, health: i32) bool {
+    if (entity_id >= MAX_ENTITIES or entity_id == NO_ENTITY) {
+        return false;
+    }
+    if (!entities[entity_id].alive) {
+        return false;
+    }
+    entities[entity_id].health = health;
+    return true;
+}
+
+/// Get entity position X - returns NaN if entity doesn't exist
+export fn get_entity_position_x(entity_id: u32) f32 {
+    if (entity_id >= MAX_ENTITIES or entity_id == NO_ENTITY) {
+        return std.math.nan(f32);
+    }
+    if (!entities[entity_id].alive) {
+        return std.math.nan(f32);
+    }
+    return entities[entity_id].position_x;
+}
+
+/// Get entity position Y - returns NaN if entity doesn't exist
+export fn get_entity_position_y(entity_id: u32) f32 {
+    if (entity_id >= MAX_ENTITIES or entity_id == NO_ENTITY) {
+        return std.math.nan(f32);
+    }
+    if (!entities[entity_id].alive) {
+        return std.math.nan(f32);
+    }
+    return entities[entity_id].position_y;
+}
+
+/// Set entity position - returns true on success
+export fn set_entity_position(entity_id: u32, x: f32, y: f32) bool {
+    if (entity_id >= MAX_ENTITIES or entity_id == NO_ENTITY) {
+        return false;
+    }
+    if (!entities[entity_id].alive) {
+        return false;
+    }
+    entities[entity_id].position_x = x;
+    entities[entity_id].position_y = y;
+    return true;
+}
+
+/// Get entity generation - returns INVALID_GENERATION if entity slot was never used
+export fn get_entity_generation(entity_id: u32) u32 {
+    if (entity_id >= MAX_ENTITIES or entity_id == NO_ENTITY) {
+        return INVALID_GENERATION;
+    }
+    return entities[entity_id].generation;
+}
+
+// =============================================================================
+// Batch Operations
+// =============================================================================
+
+/// Find all entities within radius - returns count, fills out_ids array
+/// out_ids array should be pre-allocated, max_count limits results
+export fn find_entities_in_radius(
+    center_x: f32,
+    center_y: f32,
+    radius: f32,
+    out_ids: [*]u32,
+    max_count: u32,
+) u32 {
+    var count: u32 = 0;
+    const radius_sq = radius * radius;
+
+    for (entities, 0..) |entity, i| {
+        if (entity.alive) {
+            const dx = entity.position_x - center_x;
+            const dy = entity.position_y - center_y;
+            const dist_sq = dx * dx + dy * dy;
+            if (dist_sq <= radius_sq) {
+                if (count < max_count) {
+                    out_ids[count] = @intCast(i);
+                    count += 1;
+                }
+            }
+        }
+    }
+
+    return count;
+}


### PR DESCRIPTION
## Summary

- Adds `Sentinel` class for handling FFI patterns where 0 is a valid value (like entity IDs in ECS systems)
- Pre-defined sentinels: `NO_ENTITY`, `NO_INDEX`, `INVALID_ID` 
- New `expect()` assertions: `to_be_sentinel()`, `to_not_be_sentinel()`, `to_be_valid()`, `to_be_invalid()`
- Includes `usage/ecs_entities` example project with 22 tests demonstrating sentinel patterns

## Test plan

- [x] All 22 tests in usage/ecs_entities pass
- [ ] Verify sentinel imports work: `from pzspec import Sentinel, NO_ENTITY`
- [ ] Review sentinel.py documentation and examples

Closes #18