### PR TITLE
Add PyPI publishing support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,86 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      test_pypi:
+        description: 'Publish to Test PyPI instead of PyPI'
+        required: false
+        default: 'false'
+        type: boolean
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Build package
+        run: python -m build
+
+      - name: Check package
+        run: twine check dist/*
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-to-pypi:
+    name: Publish to PyPI
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.test_pypi == 'false')
+    needs: [build]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pzspec
+    permissions:
+      id-token: write  # Required for trusted publishing
+
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish-to-testpypi:
+    name: Publish to Test PyPI
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.test_pypi == 'true'
+    needs: [build]
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/pzspec
+    permissions:
+      id-token: write  # Required for trusted publishing
+
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include LICENSE
+include README.md
+include CLAUDE.md
+include CONVENTIONS.md
+recursive-exclude usage *
+recursive-exclude .github *

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # PZSpec - Python DSL for Testing Zig Code
 
+[![PyPI version](https://badge.fury.io/py/pzspec.svg)](https://badge.fury.io/py/pzspec)
+[![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![CI](https://github.com/apotema/pzspec/actions/workflows/ci.yml/badge.svg)](https://github.com/apotema/pzspec/actions/workflows/ci.yml)
+
 A Domain-Specific Language built in Python for writing concise, readable tests for Zig code using FFI (Foreign Function Interface).
 
 ## Overview
@@ -62,23 +67,20 @@ The library will be automatically built when you run tests if it doesn't exist.
 
 ### Install PZSpec
 
-**Option 1: Install globally (Recommended)**
+**Option 1: Install from PyPI (Recommended)**
+```bash
+pip install pzspec
+```
+
+**Option 2: Install from source**
 ```bash
 pip install -e .
-# or for production:
-# pip install pzspec
 ```
 
 After installation, use the `pzspec` command from any directory:
 ```bash
 cd your-project
 pzspec  # Automatically finds and runs tests
-```
-
-**Option 2: Use without installation**
-Just run tests directly from the PZSpec project directory:
-```bash
-python run_tests.py
 ```
 
 ## Writing Tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,43 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pzspec"
+version = "0.1.0"
+description = "Python DSL for Testing Zig Code"
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.8"
+authors = [
+    {name = "PZSpec Contributors"}
+]
+keywords = ["zig", "testing", "ffi", "ctypes", "dsl"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Testing",
+    "Topic :: Software Development :: Testing :: Unit",
+]
+dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/apotema/pzspec"
+Repository = "https://github.com/apotema/pzspec"
+Issues = "https://github.com/apotema/pzspec/issues"
+
+[project.scripts]
+pzspec = "pzspec.cli:main"
+
+[tool.setuptools.packages.find]
+include = ["pzspec*"]
+exclude = ["usage*", "tests*"]

--- a/setup.py
+++ b/setup.py
@@ -1,44 +1,11 @@
 """
 Setup script for PZSpec package.
+
+Note: This file is kept for backwards compatibility.
+The primary configuration is in pyproject.toml.
 """
 
-from setuptools import setup, find_packages
-from pathlib import Path
+from setuptools import setup
 
-# Read README for long description
-readme_file = Path(__file__).parent / "README.md"
-long_description = readme_file.read_text() if readme_file.exists() else ""
-
-setup(
-    name="pzspec",
-    version="0.1.0",
-    description="Python DSL for Testing Zig Code",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    author="Your Name",
-    author_email="your.email@example.com",
-    url="https://github.com/yourusername/pzspec",
-    packages=find_packages(),
-    python_requires=">=3.8",
-    install_requires=[
-        # No external dependencies - uses only standard library
-    ],
-    classifiers=[
-        "Development Status :: 3 - Alpha",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
-        "Topic :: Software Development :: Testing",
-    ],
-    entry_points={
-        "console_scripts": [
-            "pzspec=pzspec.cli:main",
-        ],
-    },
-)
-
+if __name__ == "__main__":
+    setup()


### PR DESCRIPTION
## Summary
- Adds `pyproject.toml` with modern Python packaging configuration
- Adds GitHub Actions workflow for automatic PyPI publishing
- Updates README with PyPI badges and installation instructions

## How it works
1. **On Release**: When a new GitHub release is published, the workflow automatically:
   - Builds the source distribution and wheel
   - Publishes to PyPI using trusted publishing (OIDC)

2. **Manual Publishing**: Can also trigger manually via workflow dispatch:
   - Option to publish to Test PyPI first for testing

## Setup Required (one-time)
To enable publishing, you need to configure trusted publishing on PyPI:

1. Go to https://pypi.org/manage/account/publishing/
2. Add a new pending publisher:
   - PyPI Project Name: `pzspec`
   - Owner: `apotema`
   - Repository name: `pzspec`
   - Workflow name: `publish.yml`
   - Environment name: `pypi`

3. Create environments in GitHub repo settings:
   - `pypi` - for production PyPI
   - `testpypi` - for Test PyPI (optional)

## Test plan
- [x] Package builds successfully with `python -m build`
- [x] All required files included in package
- [ ] Verify trusted publishing works on first release

## After merge
1. Configure PyPI trusted publishing (see setup above)
2. Create a GitHub release tagged `v0.1.0`
3. Workflow will automatically publish to PyPI

Closes #20